### PR TITLE
emsdk: bump to 2.0.26 + always run test package

### DIFF
--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  2.0.10:
-    url: https://github.com/emscripten-core/emsdk/archive/refs/tags/2.0.10.tar.gz
-    sha256: 297b7dc39eba6757e4b280254129ebac05dab6a65d96d77eaab1d67ef5e7338a
+  2.0.26:
+    url: "https://github.com/emscripten-core/emsdk/archive/refs/tags/2.0.26.tar.gz"
+    sha256: "79e7166aa8eaae6e52cef1363b2d8db795d03684846066bc51f9dcf905dd58ad"

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"
@@ -15,9 +16,14 @@ class EmSDKConan(ConanFile):
 
     short_paths = True
 
-    @ property
+    @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def validate(self):
+        if hasattr(self, "settings_target") and self.settings_target:
+            if self.settings_target.os != "Emscripten":
+                raise ConanInvalidConfiguration("When using {}, target os must be Emscripten".format(self.name))
 
     def package_id(self):
         del self.info.settings.os
@@ -26,43 +32,34 @@ class EmSDKConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
-    @ staticmethod
-    def _create_dummy_file(directory):
-        tools.save(os.path.join(directory, "dummy"), "\n")
-
-    @ staticmethod
-    def _touch(filename):
-        if not os.path.isfile(filename):
-            tools.save(filename, "\n")
-
-    @ staticmethod
+    @staticmethod
     def _chmod_plus_x(filename):
-        if os.name == 'posix':
+        if os.name == "posix":
             os.chmod(filename, os.stat(filename).st_mode | 0o111)
 
     def build(self):
         with tools.chdir(self._source_subfolder):
-            emsdk = 'emsdk.bat' if os.name == 'nt' else './emsdk'
+            emsdk = "emsdk.bat" if tools.os_info.is_windows else "./emsdk"
             if os.path.isfile("python_selector"):
                 self._chmod_plus_x("python_selector")
-            self._chmod_plus_x('emsdk')
-            self.run('%s update' % emsdk)
+            self._chmod_plus_x("emsdk")
+            self.run("%s update" % emsdk)
             if os.path.isfile("python_selector"):
                 self._chmod_plus_x("python_selector")
-            self._chmod_plus_x('emsdk')
+            self._chmod_plus_x("emsdk")
 
-            self.run('%s install %s' % (emsdk, self.version))
-            self.run('%s activate %s --embedded' % (emsdk, self.version))
+            self.run("%s install %s" % (emsdk, self.version))
+            self.run("%s activate %s --embedded" % (emsdk, self.version))
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses",
                   src=self._source_subfolder)
-        self.copy(pattern='*', dst='bin',
-                  src=self._source_subfolder, excludes=('*.pc', '*Find*.cmake'))
-        emsdk = self.package_folder
-        emscripten = os.path.join(emsdk, 'bin', 'upstream', 'emscripten')
+        self.copy(pattern="*", dst="bin",
+                  src=self._source_subfolder)
+        emscripten = os.path.join(self.package_folder, "bin", "upstream", "emscripten")
         toolchain = os.path.join(
-            emscripten, 'cmake', 'Modules', 'Platform', 'Emscripten.cmake')
+            emscripten, "cmake", "Modules", "Platform", "Emscripten.cmake")
+        # FIXME: conan should add the root of conan package requirements to CMAKE_PREFIX_PATH (LIBRARY/INCLUDE -> ONLY; PROGRAM -> NEVER)
         # allow to find conan libraries
         tools.replace_in_file(toolchain,
                               "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)",
@@ -75,50 +72,57 @@ class EmSDKConan(ConanFile):
                               "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)")
 
     def _define_tool_var(self, name, value):
-        suffix = '.bat' if self.settings.os == "Windows" else ''
-        path = os.path.join(self.package_folder, 'bin', 'upstream',
-                            'emscripten', '%s%s' % (value, suffix))
+        suffix = ".bat" if self.settings.os == "Windows" else ""
+        path = os.path.join(self.package_folder, "bin", "upstream",
+                            "emscripten", "%s%s" % (value, suffix))
         self._chmod_plus_x(path)
-        self.output.info('Creating %s environment variable: %s' % (name, path))
+        self.output.info("Creating %s environment variable: %s" % (name, path))
         return path
 
     def package_info(self):
         emsdk = self.package_folder
-        em_config = os.path.join(emsdk, 'bin', '.emscripten')
-        emscripten = os.path.join(emsdk, 'bin', 'upstream', 'emscripten')
-        em_cache = os.path.join(emsdk,  'bin', '.emscripten_cache')
+        em_config = os.path.join(emsdk, "bin", ".emscripten")
+        emscripten = os.path.join(emsdk, "bin", "upstream", "emscripten")
+        em_cache = os.path.join(emsdk,  "bin", ".emscripten_cache")
         toolchain = os.path.join(
-            emscripten, 'cmake', 'Modules', 'Platform', 'Emscripten.cmake')
+            emscripten, "cmake", "Modules", "Platform", "Emscripten.cmake")
 
-        self.output.info('Appending PATH environment variable: %s' % emsdk)
+        self.output.info("Appending PATH environment variable: %s" % emsdk)
         self.env_info.PATH.append(emsdk)
 
         self.output.info(
-            'Appending PATH environment variable: %s' % emscripten)
+            "Appending PATH environment variable: %s" % emscripten)
         self.env_info.PATH.append(emscripten)
 
-        self.output.info('Creating EMSDK environment variable: %s' % emsdk)
+        self.output.info("Creating EMSDK environment variable: %s" % emsdk)
         self.env_info.EMSDK = emsdk
 
         self.output.info(
-            'Creating EMSCRIPTEN environment variable: %s' % emscripten)
+            "Creating EMSCRIPTEN environment variable: %s" % emscripten)
         self.env_info.EMSCRIPTEN = emscripten
 
         self.output.info(
-            'Creating EM_CONFIG environment variable: %s' % em_config)
+            "Creating EM_CONFIG environment variable: %s" % em_config)
         self.env_info.EM_CONFIG = em_config
 
         self.output.info(
-            'Creating EM_CACHE environment variable: %s' % em_cache)
+            "Creating EM_CACHE environment variable: %s" % em_cache)
         self.env_info.EM_CACHE = em_cache
 
         self.output.info(
-            'Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s' % toolchain)
+            "Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s" % toolchain)
         self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
 
-        self.env_info.CC = self._define_tool_var('CC', 'emcc')
-        self.env_info.CXX = self._define_tool_var('CXX', 'em++')
-        self.env_info.RANLIB = self._define_tool_var('RANLIB', 'emranlib')
-        self.env_info.AR = self._define_tool_var('AR', 'emar')
-        self.cpp_info.builddirs = ['bin/releases/src/', 'bin/upstream/emscripten/cmake/Modules/', 'bin/upstream/emscripten/cmake/Modules/Platform/', 'bin/upstream/emscripten/system/lib/libunwind/cmake/Modules/',
-                                   'bin/upstream/emscripten/system/lib/libunwind/cmake/', 'bin/upstream/emscripten/tests/cmake/target_library/', 'bin/upstream/lib/cmake/llvm/']
+        self.env_info.CC = self._define_tool_var("CC", "emcc")
+        self.env_info.CXX = self._define_tool_var("CXX", "em++")
+        self.env_info.RANLIB = self._define_tool_var("RANLIB", "emranlib")
+        self.env_info.AR = self._define_tool_var("AR", "emar")
+        self.cpp_info.builddirs = [
+            "bin/releases/src",
+            "bin/upstream/emscripten/cmake/Modules",
+            "bin/upstream/emscripten/cmake/Modules/Platform",
+            "bin/upstream/emscripten/system/lib/libunwind/cmake/Modules",
+            "bin/upstream/emscripten/system/lib/libunwind/cmake",
+            "bin/upstream/emscripten/tests/cmake/target_library",
+            "bin/upstream/lib/cmake/llvm",
+        ]

--- a/recipes/emsdk/all/test_package/CMakeLists.txt
+++ b/recipes/emsdk/all/test_package/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.18.2)
 project(test_package)
 
+option(USE_CONANBUILDINFO "Use conanbuildinfo.cmake")
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
+if(USE_CONANBUILDINFO)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
+endif()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/emsdk/all/test_package/conanfile.py
+++ b/recipes/emsdk/all/test_package/conanfile.py
@@ -1,24 +1,30 @@
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 required_conan_version = ">=1.36.0"
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "build_type", "arch", "compiler"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
     test_type = "build_requires"
+    generators = "cmake"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows":
+            self.build_requires("make/4.3")
 
     def build(self):
-        if self.settings.os == "Emscripten":
-            cmake = CMake(self, generator='MinGW Makefiles' if os.name ==
-                          'nt' else 'Unix Makefiles', parallel=False)
-            cmake.definitions["CONAN_DISABLE_CHECK_COMPILER"] = True
-            cmake.configure()
-            cmake.build()
+        cmake = CMake(self, generator="Unix Makefiles")
+        cmake.definitions["USE_CONANBUILDINFO"] = self.settings.os == "Emscripten"
+        cmake.configure()
+        cmake.build()
 
     def test(self):
-        if self.settings.os == "Emscripten":
-            test_file = os.path.join(
-                self.build_folder, "bin", "test_package.js")
-            self.run('node %s' % test_file, run_environment=True)
+        test_file = os.path.join("bin", "test_package.js")
+        assert os.path.isfile(test_file)
+        if tools.which("node"):
+            self.run("node %s" % test_file, run_environment=True)

--- a/recipes/emsdk/all/test_package/test_package.cpp
+++ b/recipes/emsdk/all/test_package/test_package.cpp
@@ -3,6 +3,6 @@
 
 int main()
 {
-    std::cout << "Bincrafters\n";
+    std::cout << "conan-center-index\n";
     return EXIT_SUCCESS;
 }

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.0.10":
+  "2.0.26":
     folder: all


### PR DESCRIPTION
Hello,

I made some changes to your emsdk pr at https://github.com/conan-io/conan-center-index/pull/6163:

- bump to 2.0.26
- add a validation check to test whether the target os, when used as a build requirement, is actually `Emscripten`
- Removed some unused static methods
- Used double quotes everywhere (the majority of recipes at cci use it)
- Allow the test package to always run

The test package can be run using:
```
conan test test_package emsdk/2.0.26@
```
or
```
conan test test_package emsdk/2.0.26@ -pr:h emsdk -pr:b default64
```
with:
```
$ conan profile show default64
Configuration for profile default64:

[settings]
os=Linux
arch=x86_64
compiler=gcc
compiler.version=11
compiler.libcxx=libstdc++11
build_type=Release
[options]
[conf]
[build_requires]
[env]
CC=gcc
CXX=g++
AS=gcc
ASM=gcc
CFLAGS=-m64
CXXFLAGS=-m64
ASFLAGS=-m64
ASMFLAGS=-m64
LDFLAGS=-m64
```
and
```
$ conan profile show emsdk
Configuration for profile emsdk:

[settings]
os=Emscripten
arch=wasm
compiler=clang
compiler.version=13
[options]
[conf]
[build_requires]
[env]
```